### PR TITLE
image compression and resizing, and random image picking

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,5 @@
 import os
 import glob
-import subprocess
 import random
 from PIL import Image
 from atproto import Client, models
@@ -22,8 +21,7 @@ LOG_FILE = "posted_images.log"  # Log file to track posted images
 def get_next_image(directory="images/"):
     """Retrieve the next unposted image to post based on numerical order."""
     images = glob.glob(directory + "*")
-    image_open = images[random.randint(0,len(images))-1]
-    image_size = os.path.getsize(image_open)
+    random.shuffle(images)  # Shuffle the images for randomness
     if not images:
         print("No images found in the directory.")
         return None

--- a/bot.py
+++ b/bot.py
@@ -67,7 +67,8 @@ def compress_image(image_path):
     print(f"Compressing image: {image_path}")
     compressed_image_path = image_path + "_compressed.jpg"
     image = Image.open(image_path)
-    image.save(compressed_image_path, "JPEG", quality=85, optimize=True)
+    rgb_image = image.convert("RGB")
+    rgb_image.save(compressed_image_path, "JPEG", quality=85, optimize=True)
     
     # Check the size of the compressed image
     image_size = os.path.getsize(compressed_image_path)
@@ -79,7 +80,7 @@ def compress_image(image_path):
     print(f"Resizing image: {image_path}")
     size_ratio = size_limit / image_size * 0.9  # 90% of the size limit as a buffer
     resized_image_path = image_path + "_resized.jpg"
-    resized_image = image.resize((int(image.width * size_ratio), int(image.height * size_ratio)))
+    resized_image = rgb_image.resize((int(image.width * size_ratio), int(image.height * size_ratio)))
     resized_image.save(resized_image_path, "JPEG", quality=85, optimize=True)
     return resized_image_path
 

--- a/bot.py
+++ b/bot.py
@@ -2,6 +2,7 @@ import os
 import glob
 import subprocess
 import random
+from PIL import Image
 from atproto import Client, models
 from dotenv import load_dotenv
 from datetime import datetime
@@ -54,6 +55,45 @@ def is_image_posted(image_path):
     except FileNotFoundError:
         return False
 
+def compress_image(image_path):
+    """use PIL to compress the image if it would be above the upload size limit"""
+    size_limit = 976560  # 976.56 KB
+    
+    # Check the size of the image
+    image_size = os.path.getsize(image_path)
+    if image_size <= size_limit:
+        # Image is within the size limit - all good!
+        return image_path
+    
+    # Compress the image to .jpg format
+    print(f"Compressing image: {image_path}")
+    compressed_image_path = image_path + "_compressed.jpg"
+    image = Image.open(image_path)
+    image.save(compressed_image_path, "JPEG", quality=85, optimize=True)
+    
+    # Check the size of the compressed image
+    image_size = os.path.getsize(compressed_image_path)
+    if image_size <= size_limit:
+        # Compressed image is within the size limit
+        return compressed_image_path
+    
+    # Resize the image if it is still above the size limit
+    print(f"Resizing image: {image_path}")
+    size_ratio = size_limit / image_size * 0.9  # 90% of the size limit as a buffer
+    resized_image_path = image_path + "_resized.jpg"
+    resized_image = image.resize((int(image.width * size_ratio), int(image.height * size_ratio)))
+    resized_image.save(resized_image_path, "JPEG", quality=85, optimize=True)
+    return resized_image_path
+
+def delete_image_copies(image_path):
+    """Delete the compressed and resized copies of the image, if present."""
+    compressed_image_path = image_path + "_compressed.jpg"
+    resized_image_path = image_path + "_resized.jpg"
+    for file_path in [compressed_image_path, resized_image_path]:
+        if os.path.exists(file_path):
+            os.remove(file_path)
+            print(f"Deleted: {file_path}")
+
 def post_to_bluesky():
     """Logs in and posts an image with text to Bluesky."""
     try:
@@ -92,13 +132,17 @@ def post_to_bluesky():
         ]
 
         # Read image data
-        with open(image_path, "rb") as img:
+        adjusted_image_path = compress_image(image_path)
+        with open(adjusted_image_path, "rb") as img:
             image_data = img.read()
 
         # Upload the image
         upload = client.upload_blob(image_data)
         images = [models.AppBskyEmbedImages.Image(alt="hourly hibiki", image=upload.blob)]
         embed = models.AppBskyEmbedImages.Main(images=images)
+        
+        # Delete the compressed and resized copies of the image
+        delete_image_copies(image_path)
 
         # Create the post with rich text facets
         client.com.atproto.repo.create_record(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 atproto==0.0.55  # Replace with the correct version for Bluesky's library
 python-dotenv==1.0.0  # To load environment variables from .env
+pillow==10.2.0 # To resize images and convert between formats


### PR DESCRIPTION
This PR contains two additions:

- an additional step to ensure the images posted by the bot are always below the upload file size limit. First, an attempt is made to compress the image to .jpg to save space. If this fails, it is instead resized to make it small enough.
- replaced the unused lines for picking a random image with a shuffling operation. This ensures a random image is chosen each time without relying on undefined behavior of glob.glob.